### PR TITLE
Add explicit check for age locked mobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nu.nerd</groupId>
 	<artifactId>MobLimiter</artifactId>
-	<version>1.1</version>
+	<version>1.1.1</version>
 	<packaging>jar</packaging>
 	<name>MobLimiter</name>
 	<properties>

--- a/src/nu/nerd/moblimiter/MobLimiter.java
+++ b/src/nu/nerd/moblimiter/MobLimiter.java
@@ -187,6 +187,12 @@ public class MobLimiter extends JavaPlugin implements Listener {
     }
 
     public void applyAgeCap(Animals en) {
+        if (en.getAgeLock() == true) {
+            if (debugAgeCap) {
+                getLogger().info("Age locked " + getMobDescription(en) + " with age " + en.getAge() + " was not age capped");
+            }
+            return;
+        }
         if (ageCapBaby >= 0 && !en.isAdult()) {
             en.setAge(Math.max(en.getAge(), -ageCapBaby));
         } else if (ageCapBreed >= 0 && en.isAdult()) {


### PR DESCRIPTION
During breeding events, the ages of surrouding mobs were previously changed
without regard to their age lock status, this adds a check for if they
have been age locked to prevent a situation where an age locked baby mob
would become an adult.  Bukkit should probably be honoring age locks
regardless of age, so this is more of a workaround for how ages are
handled than actual fix of something wrong with the original method.

Tested against Spigot 1543 and [KeepBabyMobs](https://github.com/tompreuss/KeepBabyMobs) 0.1.1
