### PR TITLE
Fix for entity culling breaking in 1.17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 
 	<groupId>nu.nerd</groupId>
 	<artifactId>MobLimiter</artifactId>
-	<version>2.0.2</version>
+	<version>2.1.2</version>
 
 
 	<repositories>
 		<repository>
-			<id>spigot-repo</id>
-			<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+			<id>papermc-repo</id>
+			<url>https://papermc.io/repo/repository/maven-public/</url>
 		</repository>
         <repository>
             <id>md_5-releases</id>
@@ -23,11 +23,6 @@
 
 
 	<dependencies>
-		<dependency>
-			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot-api</artifactId>
-			<version>1.9-R0.1-SNAPSHOT</version>
-		</dependency>
         <dependency>
             <!-- This is required because LogBlock is a pain -->
             <groupId>de.diddiz</groupId>
@@ -41,6 +36,11 @@
             <artifactId>logblock</artifactId>
             <version>1.94</version>
         </dependency>
+		<dependency>
+			<groupId>io.papermc.paper</groupId>
+			<artifactId>paper-api</artifactId>
+			<version>1.20.1-R0.1-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
 	<repositories>
 		<repository>
-			<id>papermc-repo</id>
-			<url>https://papermc.io/repo/repository/maven-public/</url>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
 		</repository>
         <repository>
             <id>md_5-releases</id>
@@ -37,9 +37,9 @@
             <version>1.94</version>
         </dependency>
 		<dependency>
-			<groupId>io.papermc.paper</groupId>
-			<artifactId>paper-api</artifactId>
-			<version>1.20.1-R0.1-SNAPSHOT</version>
+			<groupId>org.spigotmc</groupId>
+			<artifactId>spigot-api</artifactId>
+			<version>1.20-R0.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/src/nu/nerd/moblimiter/CommandHandler.java
+++ b/src/nu/nerd/moblimiter/CommandHandler.java
@@ -106,9 +106,9 @@ public class CommandHandler implements CommandExecutor {
                     " it is configured:\n");
 
             msg.append(ChatColor.YELLOW);
-            msg.append("1. Chunk unload culling\n");
+            msg.append("1. Entity unload culling\n");
             msg.append(ChatColor.GOLD);
-            msg.append("Mobs are culled down to a defined maximum whenever a chunk unloads or the server restarts.\n");
+            msg.append("Mobs are culled down to a defined maximum whenever a cluster of entities unloads or the server restarts.\n");
 
             msg.append(ChatColor.YELLOW);
             msg.append("2. Real-time spawn limiting\n");

--- a/src/nu/nerd/moblimiter/MobLimiter.java
+++ b/src/nu/nerd/moblimiter/MobLimiter.java
@@ -2,7 +2,7 @@ package nu.nerd.moblimiter;
 
 import nu.nerd.moblimiter.configuration.Configuration;
 import nu.nerd.moblimiter.limiters.AgeLimiter;
-import nu.nerd.moblimiter.limiters.ChunkUnloadLimiter;
+import nu.nerd.moblimiter.limiters.EntityUnloadLimiter;
 import nu.nerd.moblimiter.limiters.SpawnLimiter;
 import nu.nerd.moblimiter.logblock.LogBlockWrapper;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,7 +13,7 @@ public class MobLimiter extends JavaPlugin {
 
     public static MobLimiter instance;
     private Configuration configuration;
-    private ChunkUnloadLimiter chunkUnloadLimiter;
+    private EntityUnloadLimiter chunkUnloadLimiter;
     private AgeLimiter ageLimiter;
     private LogBlockWrapper logBlock;
 
@@ -21,7 +21,7 @@ public class MobLimiter extends JavaPlugin {
     public void onEnable() {
         MobLimiter.instance = this;
         configuration = new Configuration();
-        chunkUnloadLimiter = new ChunkUnloadLimiter();
+        chunkUnloadLimiter = new EntityUnloadLimiter();
         ageLimiter = new AgeLimiter();
         logBlock = new LogBlockWrapper();
         new SpawnLimiter();

--- a/src/nu/nerd/moblimiter/limiters/ChunkUnloadLimiter.java
+++ b/src/nu/nerd/moblimiter/limiters/ChunkUnloadLimiter.java
@@ -7,11 +7,12 @@ import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.world.ChunkUnloadEvent;
+import org.bukkit.event.world.EntitiesUnloadEvent;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -24,27 +25,28 @@ public class ChunkUnloadLimiter implements Listener {
 
     private MobLimiter plugin;
 
+    private Chunk chunk;
+
 
     public ChunkUnloadLimiter() {
         plugin = MobLimiter.instance;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onChunkUnload(final ChunkUnloadEvent event) {
-        removeMobs(event.getChunk());
+    @EventHandler
+    public void onEntitiesUnloaded(EntitiesUnloadEvent event) {
+        removeMobs(event.getEntities());
     }
 
 
     /**
      * Remove excess mobs in a chunk, if chunk unload culling is enabled for the mob type.
      * This is the default behavior from MobLimiter 1.x.
-     * @param chunk The chunk to cull mobs in
+     * @param entities The list of entities being unloaded
      */
-    private void removeMobs(Chunk chunk) {
+    private void removeMobs(List<Entity> entities) {
         Map<String, Integer> count = new HashMap<String, Integer>();
-        for (Entity entity : chunk.getEntities()) {
+        for (Entity entity : entities) {
 
             // Constrain entities to be removed to limitable mobs, excluding villagers
             if (entity.isDead() || !EntityHelper.isLimitableMob(entity) || entity instanceof Villager) continue;
@@ -83,7 +85,7 @@ public class ChunkUnloadLimiter implements Listener {
     public void removeAllMobs() {
         for (World world : plugin.getServer().getWorlds()) {
             for (Chunk chunk : world.getLoadedChunks()) {
-                removeMobs(chunk);
+                removeMobs(Arrays.asList(chunk.getEntities()));
             }
         }
     }

--- a/src/nu/nerd/moblimiter/limiters/EntityUnloadLimiter.java
+++ b/src/nu/nerd/moblimiter/limiters/EntityUnloadLimiter.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * Cull applicable mobs on chunk unload.
  * This is based on behavior from the original MobLimiter 1.x.
  */
-public class ChunkUnloadLimiter implements Listener {
+public class EntityUnloadLimiter implements Listener {
 
 
     private MobLimiter plugin;
@@ -28,7 +28,7 @@ public class ChunkUnloadLimiter implements Listener {
     private Chunk chunk;
 
 
-    public ChunkUnloadLimiter() {
+    public EntityUnloadLimiter() {
         plugin = MobLimiter.instance;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }


### PR DESCRIPTION
Replaced the chunk unload check for a new entity unload check, as since 1.17 entities unload before chunks, breaking the old system.